### PR TITLE
解决SQL语句中无表注释或者部分字段无注释时的SQL解析错误

### DIFF
--- a/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
+++ b/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
@@ -51,7 +51,7 @@ public class TableParseUtil {
         }
 
         // class Comment
-        String classComment = null;
+        String classComment = "";
         if (tableSql.contains("COMMENT=")) {
             String classCommentTmp = tableSql.substring(tableSql.lastIndexOf("COMMENT=")+8).trim();
             if (classCommentTmp.contains("'") || classCommentTmp.indexOf("'")!=classCommentTmp.lastIndexOf("'")) {
@@ -117,7 +117,7 @@ public class TableParseUtil {
                     }
 
                     // field comment
-                    String fieldComment = null;
+                    String fieldComment = "";
                     if (columnLine.contains("COMMENT")) {
                         String commentTmp = fieldComment = columnLine.substring(columnLine.indexOf("COMMENT")+7).trim();	// '用户ID',
                         if (commentTmp.contains("'") || commentTmp.indexOf("'")!=commentTmp.lastIndexOf("'")) {


### PR DESCRIPTION
1.classComment 默认值从null改为""
2.fieldComment 默认值从null改为""
3.PR理由
 由于建表时的不规范或者一些老项目的SQL建表语句，表注释或者大部分的字段注释都没有，代码要对这部分SQL语句保持必要的容忍性，即对SQL语句的不规范性要保持理解