### PR TITLE
bugs fix

### DIFF
--- a/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
+++ b/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
@@ -51,7 +51,7 @@ public class TableParseUtil {
         }
 
         // class Comment
-        String classComment = null;
+        String classComment = "";
         if (tableSql.contains("COMMENT=")) {
             String classCommentTmp = tableSql.substring(tableSql.lastIndexOf("COMMENT=")+8).trim();
             if (classCommentTmp.contains("'") || classCommentTmp.indexOf("'")!=classCommentTmp.lastIndexOf("'")) {
@@ -78,6 +78,24 @@ public class TableParseUtil {
                 String commentTmpFinal = commentTmp.replaceAll(",", "，");
                 fieldListTmp = fieldListTmp.replace(matcher.group(), commentTmpFinal);
             }
+        }
+
+        // remove PRIMARY KEY
+        Matcher primaryKeyMatcher = Pattern.compile("[\\s]*PRIMARY KEY .*(\\),|\\))").matcher(fieldListTmp);
+        while(primaryKeyMatcher.find()){
+            fieldListTmp = fieldListTmp.replace(primaryKeyMatcher.group(),"");
+        }
+
+        // remove UNIQUE KEY
+        Matcher uniqueKeyMathcer = Pattern.compile("[\\s]*UNIQUE KEY .*(\\),|\\))").matcher(fieldListTmp);
+        while(uniqueKeyMathcer.find()){
+            fieldListTmp = fieldListTmp.replace(uniqueKeyMathcer.group(), "");
+        }
+
+        // remove KEY
+        Matcher keyMathcer = Pattern.compile("[\\s]*KEY .*(\\),|\\))").matcher(fieldListTmp);
+        while(keyMathcer.find()){
+            fieldListTmp = fieldListTmp.replace(keyMathcer.group(), "");
         }
 
 
@@ -110,7 +128,7 @@ public class TableParseUtil {
                         fieldClass = Double.TYPE.getSimpleName();
                     } else if (columnLine.startsWith("datetime") || columnLine.startsWith("timestamp")) {
                         fieldClass = Date.class.getSimpleName();
-                    } else if (columnLine.startsWith("varchar") || columnLine.startsWith("text")) {
+                    } else if (columnLine.startsWith("varchar") || columnLine.startsWith("text") || columnLine.startsWith("char")) {
                         fieldClass = String.class.getSimpleName();
                     } else if (columnLine.startsWith("decimal")) {
                         fieldClass = BigDecimal.class.getSimpleName();

--- a/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
+++ b/xxl-code-generator-admin/src/main/java/com/xxl/codegenerator/admin/core/util/TableParseUtil.java
@@ -51,7 +51,7 @@ public class TableParseUtil {
         }
 
         // class Comment
-        String classComment = "";
+        String classComment = null;
         if (tableSql.contains("COMMENT=")) {
             String classCommentTmp = tableSql.substring(tableSql.lastIndexOf("COMMENT=")+8).trim();
             if (classCommentTmp.contains("'") || classCommentTmp.indexOf("'")!=classCommentTmp.lastIndexOf("'")) {


### PR DESCRIPTION
1.数据库类型为char，解析成object
2.建表语句包含unique key，key里的属性，会重复生成。把建表语句里的primary key、unique key、key从建表语句中排除。

问题2测试用例：
CREATE TABLE `userinfo` (
  `user_id` int(11) NOT NULL AUTO_INCREMENT COMMENT '用户ID',
  `username` varchar(255) NOT NULL COMMENT '用户名',
  `addtime` datetime NOT NULL COMMENT '创建时间',
  PRIMARY KEY (`user_id`),
  UNIQUE KEY `instance_id` (`user_id`,`username`),
  KEY `username` (`username`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='用户信息'
                                            